### PR TITLE
Add support for downloading spot data and update tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,15 @@ downloader = BybitBulkDownloader(data_type='spot_index')
 downloader.run_download()
 ```
 
+### Download all spot data
+
+```python
+from bybit_bulk_downloader.downloader import BybitBulkDownloader
+
+downloader = BybitBulkDownloader(data_type='spot')
+downloader.run_download()
+```
+
 ### Download specific trading pair data
 
 ```python
@@ -78,6 +87,7 @@ python -m pytest
 | :-------------------- | :--: | :--: |
 | kline_for_metatrader4 | ❌   | ✅   |
 | premium_index         | ✅   | ❌   |
+| spot                  | ✅   | ❌   |
 | spot_index            | ✅   | ❌   |
 | trading               | ❌   | ✅   |
 

--- a/bybit_bulk_downloader/downloader.py
+++ b/bybit_bulk_downloader/downloader.py
@@ -35,6 +35,7 @@ class BybitBulkDownloader:
     _DATA_TYPE = (
         "kline_for_metatrader4",
         "premium_index",
+        "spot",
         "spot_index",
         "trading",
     )

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 requests~=2.32.0
 setuptools~=70.0.0
-rich~=10.16.2
-pytest~=4.6.11
+rich~=14.2.0
+pytest~=9.0.1
+pytest-mock~=3.15.1
 beautifulsoup4~=4.12.2
-pybit~=2.4.1
+pybit~=5.13.0

--- a/tests/integration/test_download.py
+++ b/tests/integration/test_download.py
@@ -18,6 +18,7 @@ def dynamic_test_params():
     for data_type in [
         "kline_for_metatrader4",
         "premium_index",
+        "spot",
         "spot_index",
         "trading",
     ]:
@@ -68,6 +69,18 @@ def test_download(tmpdir, data_type):
         assert os.path.exists(
             os.path.join(
                 tmpdir, BYBIT_DATA, "spot_index/ADAUSD/ADAUSD2022-03-24_index_price.csv"
+            )
+        )
+
+    elif data_type == "spot":
+        single_download_url = "https://public.bybit.com/spot/BTCUSDT/BTCUSDT_2022-11-10.csv.gz"
+        downloader.download(single_download_url)
+        # If exists csv file on destination dir, test is passed.
+        assert os.path.exists(
+            os.path.join(
+                tmpdir,
+                BYBIT_DATA,
+                "spot/BTCUSDT/BTCUSDT_2022-11-10.csv",
             )
         )
 

--- a/tests/unit/test_downloader.py
+++ b/tests/unit/test_downloader.py
@@ -70,3 +70,38 @@ def test_invalid_data_type():
             data_type="invalid_type",
         )
     assert "Invalid data_type:" in str(exc_info.value)
+
+
+@pytest.mark.unit
+def test_spot_data_type(tmpdir, mock_response):
+    """Test spot data type download"""
+    downloader = BybitBulkDownloader(
+        destination_dir=tmpdir,
+        data_type="spot",
+    )
+    test_url = "https://public.bybit.com/spot/BTCUSDT/BTCUSDT2023-01-01.csv.gz"
+    downloader.download(test_url)
+
+    # Verify the request was made
+    assert mock_response.call_count == 1
+    args, kwargs = mock_response.call_args
+    assert args[0] == test_url
+
+    # Verify the file was saved correctly
+    expected_path = os.path.join(
+        tmpdir,
+        BYBIT_DATA,
+        "spot/BTCUSDT/BTCUSDT2023-01-01.csv",
+    )
+    assert os.path.exists(expected_path)
+
+
+@pytest.mark.unit
+def test_valid_spot_data_type():
+    """Test that spot is a valid data type"""
+    downloader = BybitBulkDownloader(
+        destination_dir="test",
+        data_type="spot",
+    )
+    assert downloader._data_type == "spot"
+


### PR DESCRIPTION
- Introduced functionality to download all spot data in README.
- Updated downloader to include 'spot' as a valid data type.
- Enhanced integration tests to validate spot data downloads.
- Added unit tests for spot data type handling.
- Updated requirements for compatibility.